### PR TITLE
Add prefetch service

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from typing import List, Literal, Optional
 import uuid
 
 from .sockets.room import socket_app
+from .services.prefetch import prefetch_phrases
 
 app = FastAPI(title="EMOGUCHI API", version="v1")
 
@@ -86,7 +87,7 @@ async def delete_room(room_id: str, room=Depends(require_host_token)):
 
 @app.post("/api/v1/rooms/{room_id}/prefetch", response_model=PrefetchResult)
 async def prefetch(room_id: str, req: PrefetchRequest, room=Depends(require_host_token)):
-    phrases = [f"phrase {i}" for i in range(req.batchSize)]
+    phrases = await prefetch_phrases(req.batchSize)
     return PrefetchResult(phrases=phrases)
 
 

--- a/backend/services/prefetch.py
+++ b/backend/services/prefetch.py
@@ -1,0 +1,47 @@
+import os
+import asyncio
+from typing import List
+
+import openai
+
+# Fallback phrases used when the OpenAI request fails or times out
+FALLBACK_PHRASES = [
+    "よろしくお願いします！",
+    "さあ、始めましょう。",
+    "今日はいい天気ですね。",
+    "準備はできていますか？",
+    "これが予備のセリフです。",
+]
+
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
+
+
+async def prefetch_phrases(batch_size: int) -> List[str]:
+    """Fetch phrases from OpenAI with timeout and fallback."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return FALLBACK_PHRASES[: batch_size]
+
+    prompt = (
+        f"次のゲーム用に短いセリフを{batch_size}個日本語で生成してください。"
+        "箇条書きで出力してください。"
+    )
+    try:
+        response = await asyncio.wait_for(
+            openai.ChatCompletion.acreate(
+                api_key=api_key,
+                model=OPENAI_MODEL,
+                messages=[
+                    {"role": "system", "content": "あなたはセリフ生成ボットです。"},
+                    {"role": "user", "content": prompt},
+                ],
+            ),
+            timeout=3,
+        )
+        text = response.choices[0].message.content
+        phrases = [line.lstrip("-• ").strip() for line in text.splitlines() if line.strip()]
+        if len(phrases) >= batch_size:
+            return phrases[:batch_size]
+        return phrases or FALLBACK_PHRASES[: batch_size]
+    except Exception:
+        return FALLBACK_PHRASES[: batch_size]


### PR DESCRIPTION
## Summary
- add async `prefetch_phrases` service using OpenAI with timeout and fallback
- call new service from `/rooms/{room_id}/prefetch` endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841942c05608321b06064438a039fea