### PR TITLE
Use environment token for debug API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Literal, Optional
 import uuid
+import os
 
 from .sockets.room import socket_app
 
@@ -26,7 +27,7 @@ app.mount("/ws", socket_app)
 
 # In-memory state store
 rooms = {}
-DEBUG_TOKEN = "debug"
+DEBUG_TOKEN = os.getenv("DEBUG_API_TOKEN")
 
 class RoomConfig(BaseModel):
     mode: Literal["basic", "advanced"] = "basic"
@@ -92,6 +93,8 @@ async def prefetch(room_id: str, req: PrefetchRequest, room=Depends(require_host
 
 @app.get("/api/v1/debug/rooms")
 async def debug_rooms(x_debug_token: Optional[str] = Header(None)):
+    if DEBUG_TOKEN is None:
+        raise HTTPException(status_code=404, detail="Debug API not enabled")
     if x_debug_token != DEBUG_TOKEN:
         raise HTTPException(status_code=401, detail="Invalid debug token")
     return {"rooms": list(rooms.keys())}


### PR DESCRIPTION
## Summary
- read debug token from `DEBUG_API_TOKEN` env var
- disable the `/api/v1/debug/rooms` endpoint when the token is unset

## Testing
- `python -m py_compile backend/main.py backend/sockets/room.py`


------
https://chatgpt.com/codex/tasks/task_e_684194386ac083218fef667a45a389b7